### PR TITLE
Add customer search endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This project is a Node.js/Express API for managing customers, products, and orde
 - `PUT    /api/customers/:id` — Update a customer
 - `GET    /api/customers/:id` — Get a customer by ID
 - `DELETE /api/customers/:id` — Delete a customer
+- `GET    /api/customers` — Search customers by `email` or `phoneNumber` query params
 
 ### Products
 - `POST   /api/products` — Create or upsert a product

--- a/final-project/source/api/customers.mjs
+++ b/final-project/source/api/customers.mjs
@@ -53,6 +53,12 @@ router.get("/customers/:id", async (req, res) => {
   res.send(builder.build(response)).status(200);
 });
 
+router.get("/customers", async (req, res) => {
+  const { email, phoneNumber } = req.query;
+  const customers = await CustomerController.search({ email, phoneNumber });
+  res.status(200).send(builder.build({ customers }));
+});
+
 router.delete("/customers/:id", async (req, res) => {
   console.log("Handling GET customer request");
   const response = await CustomerController.deleteById(req.params.id);

--- a/final-project/source/controllers/CustomerController.mjs
+++ b/final-project/source/controllers/CustomerController.mjs
@@ -70,4 +70,29 @@ RETURNING id, name, email, phone_number;`,
       connection.release();
     }
   }
+
+  /**
+   * Search customers by email or phone number
+   * @param {{email?: string, phoneNumber?: string}} options
+   */
+  static async search({ email, phoneNumber } = {}) {
+    const { db } = Connection.getInstance();
+    let query =
+      "SELECT id, name, email, phone_number FROM customers";
+    const params = [];
+    const conditions = [];
+    if (email) {
+      conditions.push(`email ILIKE $${params.length + 1}`);
+      params.push(`%${email}%`);
+    }
+    if (phoneNumber) {
+      conditions.push(`phone_number ILIKE $${params.length + 1}`);
+      params.push(`%${phoneNumber}%`);
+    }
+    if (conditions.length) {
+      query += " WHERE " + conditions.join(" OR ");
+    }
+    const result = await db.query(query, params);
+    return result.rows.map((row) => ({ customer: fromRow(row) }));
+  }
 }


### PR DESCRIPTION
## Summary
- add search function to CustomerController
- support GET /api/customers for searching by email or phone number
- document new endpoint in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f7bd53af483309fad9c7794d18545